### PR TITLE
Add Bravely Baby splash screen

### DIFF
--- a/src/assets/baby-illustration.svg
+++ b/src/assets/baby-illustration.svg
@@ -1,0 +1,34 @@
+<svg width="200" height="220" viewBox="0 0 200 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="babyIllustrationTitle babyIllustrationDesc">
+  <title id="babyIllustrationTitle">Illustration of a peaceful swaddled baby</title>
+  <desc id="babyIllustrationDesc">A stylized illustration of a sleeping baby wrapped in a green swaddle with gentle botanical accents.</desc>
+  <defs>
+    <linearGradient id="swaddleGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#B7D3C1" />
+      <stop offset="100%" stop-color="#8BAE8C" />
+    </linearGradient>
+    <linearGradient id="cheekGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F5B7B1" stop-opacity="0.75" />
+      <stop offset="100%" stop-color="#F1948A" stop-opacity="0.2" />
+    </linearGradient>
+    <clipPath id="ovalClip">
+      <ellipse cx="100" cy="110" rx="96" ry="108" />
+    </clipPath>
+  </defs>
+  <g clip-path="url(#ovalClip)">
+    <rect x="4" y="2" width="192" height="216" rx="96" fill="#F7F1E8" />
+    <ellipse cx="101" cy="93" rx="58" ry="62" fill="#E8C4A2" />
+    <path d="M69 98C75 110 93 114 101 114C109 114 125 110 133 98" stroke="#6D432E" stroke-width="4" stroke-linecap="round" />
+    <path d="M84 84C84 81.2386 81.7614 79 79 79C76.2386 79 74 81.2386 74 84" stroke="#6D432E" stroke-width="4" stroke-linecap="round" />
+    <path d="M126 84C126 81.2386 123.761 79 121 79C118.239 79 116 81.2386 116 84" stroke="#6D432E" stroke-width="4" stroke-linecap="round" />
+    <path d="M90 104C94 108 108 108 112 104" stroke="#6D432E" stroke-width="3" stroke-linecap="round" />
+    <ellipse cx="80" cy="98" rx="8" ry="5" fill="url(#cheekGradient)" />
+    <ellipse cx="122" cy="98" rx="8" ry="5" fill="url(#cheekGradient)" />
+    <path d="M50 135C60 124 90 108 114 112C140 116 164 148 166 168C168 188 148 206 118 210C88 214 56 202 42 178C28 154 40 142 50 135Z" fill="url(#swaddleGradient)" />
+    <path d="M80 150C88 150 114 160 126 184" stroke="#EDF3EA" stroke-width="6" stroke-linecap="round" />
+    <path d="M58 166C66 164 90 168 106 190" stroke="#EDF3EA" stroke-width="6" stroke-linecap="round" />
+  </g>
+  <ellipse cx="20" cy="96" rx="8" ry="18" stroke="#B5C3A8" stroke-width="4" stroke-linecap="round" />
+  <ellipse cx="180" cy="96" rx="8" ry="18" stroke="#B5C3A8" stroke-width="4" stroke-linecap="round" />
+  <path d="M25 60C16 58 10 46 12 36C14 26 22 20 31 22" stroke="#B5C3A8" stroke-width="4" stroke-linecap="round" />
+  <path d="M175 60C184 58 190 46 188 36C186 26 178 20 169 22" stroke="#B5C3A8" stroke-width="4" stroke-linecap="round" />
+</svg>

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Bravely Baby — Splash</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main class="splash-card" role="presentation">
+    <section class="header">
+      <div class="illustration-wrapper" aria-hidden="true">
+        <img src="assets/baby-illustration.svg" alt="" width="180" height="198" loading="lazy" />
+      </div>
+      <div class="branding">
+        <h1><span>Bravely</span>Baby</h1>
+        <p>
+          taking care of.<br />
+          <strong>Every feed.<br />Every fighter.<br />Every family.</strong>
+        </p>
+      </div>
+    </section>
+    <section class="footer">
+      <button type="button" class="sign-in">Sign In</button>
+      <p class="signature" aria-label="for Landry">for Landry</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,174 @@
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;600&family=Source+Sans+3:wght@400;600&display=swap');
+
+:root {
+  --background: #f8f4ed;
+  --text-primary: #285244;
+  --text-secondary: rgba(40, 82, 68, 0.8);
+  --muted: rgba(40, 82, 68, 0.55);
+  --button-bg: #2c6950;
+  --button-text: #fefcf5;
+  --accent-leaf: rgba(163, 182, 154, 0.4);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+  font-family: 'Source Sans 3', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--background);
+  color: var(--text-secondary);
+}
+
+body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.65), transparent 60%),
+              radial-gradient(circle at bottom, rgba(218, 227, 213, 0.35), transparent 70%),
+              var(--background);
+  padding: 1.5rem;
+}
+
+.splash-card {
+  width: min(100%, 420px);
+  max-width: 420px;
+  background: rgba(254, 252, 245, 0.7);
+  border-radius: 32px;
+  padding: 3.5rem 2.75rem 2.75rem;
+  box-shadow: 0 40px 80px rgba(68, 81, 73, 0.15);
+  position: relative;
+  overflow: hidden;
+}
+
+.splash-card::before,
+.splash-card::after {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+  background-repeat: no-repeat;
+}
+
+.splash-card::before {
+  width: 240px;
+  height: 160px;
+  bottom: -70px;
+  left: -40px;
+  background-image: url('data:image/svg+xml,%3Csvg width="240" height="160" viewBox="0 0 240 160" xmlns="http://www.w3.org/2000/svg" fill="none"%3E%3Cpath d="M40 120C60 104 70 70 48 60" stroke="rgba(163,182,154,0.45)" stroke-width="6" stroke-linecap="round"/%3E%3Cpath d="M80 132C108 112 112 64 88 46" stroke="rgba(163,182,154,0.4)" stroke-width="6" stroke-linecap="round"/%3E%3Cpath d="M116 140C150 116 150 66 120 40" stroke="rgba(163,182,154,0.35)" stroke-width="6" stroke-linecap="round"/%3E%3C/svg%3E');
+}
+
+.splash-card::after {
+  width: 220px;
+  height: 140px;
+  top: -60px;
+  right: -30px;
+  background-image: url('data:image/svg+xml,%3Csvg width="220" height="140" viewBox="0 0 220 140" xmlns="http://www.w3.org/2000/svg" fill="none"%3E%3Cpath d="M180 20C156 38 144 80 170 94" stroke="rgba(163,182,154,0.35)" stroke-width="6" stroke-linecap="round"/%3E%3Cpath d="M146 12C118 36 110 86 140 108" stroke="rgba(163,182,154,0.32)" stroke-width="6" stroke-linecap="round"/%3E%3Cpath d="M112 4C80 32 74 82 104 108" stroke="rgba(163,182,154,0.3)" stroke-width="6" stroke-linecap="round"/%3E%3C/svg%3E');
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 1.75rem;
+}
+
+.illustration-wrapper {
+  width: 190px;
+  height: 210px;
+  border-radius: 100px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(219, 228, 215, 0.45));
+  display: grid;
+  place-items: center;
+  box-shadow: inset 0 16px 32px rgba(255, 255, 255, 0.8);
+}
+
+.branding h1 {
+  margin: 0;
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  font-weight: 600;
+  font-size: 2.75rem;
+  letter-spacing: 0.05em;
+  color: var(--text-primary);
+}
+
+.branding h1 span {
+  display: block;
+  font-weight: 400;
+  font-size: 2.4rem;
+}
+
+.branding p {
+  margin: 1.25rem 0 0;
+  font-size: 0.98rem;
+  line-height: 1.7;
+  color: var(--muted);
+  max-width: 18ch;
+}
+
+.branding p strong {
+  display: block;
+  color: var(--text-primary);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  margin-top: 3rem;
+}
+
+button.sign-in {
+  font: 600 1rem 'Source Sans 3', sans-serif;
+  padding: 0.9rem 2.75rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #2f7256, #265340);
+  color: var(--button-text);
+  box-shadow: 0 16px 30px rgba(56, 95, 77, 0.25);
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+button.sign-in:hover,
+button.sign-in:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 36px rgba(56, 95, 77, 0.32);
+}
+
+button.sign-in:focus-visible {
+  outline: 3px solid rgba(47, 114, 86, 0.35);
+  outline-offset: 4px;
+}
+
+.signature {
+  font-size: 0.75rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: rgba(40, 82, 68, 0.35);
+}
+
+@media (max-width: 420px) {
+  .splash-card {
+    padding: 3rem 1.75rem 2.25rem;
+    border-radius: 28px;
+  }
+
+  .branding h1 {
+    font-size: 2.4rem;
+  }
+
+  .branding h1 span {
+    font-size: 2.1rem;
+  }
+
+  .branding p {
+    max-width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone HTML splash screen for the Bravely Baby concept
- style the layout to match the provided mock with typography, gradients, and decorative accents
- include an inline SVG illustration to complete the hero treatment

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68d971c61178832ba2c354e13342e5a0