### PR TITLE
feat: initialize python task core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__/
 .vscode/
 coverage/
 *.log
+.venv/
+*.egg-info/

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ run:
 	fi
 
 test:
-	@echo "No tests configured. Add your language test runner here (e.g., npm test or pytest)"
+	@python -m pytest

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
  > ⚠️ Proprietary — contact lifeoflandry@gmail.com to request a license or reuse permission. Contributions require a signed Contributor License Agreement (see `CLA.md`).
 
- Small, adaptable project template meant to be developed inside a devcontainer. Use this repo as a sandbox for caregiving tools and small web apps; when you add a runtime (Node, Python, etc.) include the appropriate manifest and update this README.
+Small, adaptable project template meant to be developed inside a devcontainer. The current codebase implements a lightweight Python task-management core that can back CLIs, web APIs, or automations. Extend it with additional runtimes (Node, Python, etc.) as you grow the project.
 
  Quick links
  - CLA and contributor instructions: `CLA.md` / `CONTRIBUTING.md`
@@ -12,22 +12,36 @@
  - Devcontainer: `.devcontainer/devcontainer.json`
  - CI workflows: `.github/workflows/`
 
- Getting started (local)
- 1. Clone the repo:
-     ```bash
-     git clone https://github.com/BravelyBaby/psychic-barnacle.git
-     cd psychic-barnacle
-     ```
- 2. Open and run the devcontainer (recommended) or use the host environment.
- 3. Use `Makefile` targets for quick actions:
-     ```bash
-     # build/run (Dockerfile required)
-     make build
-     make run
+## Features
 
-     # run tests (replace with your project's test runner)
-     make test
-     ```
+- `Task` dataclass with validation, ordering, and serialization helpers.
+- `TaskManager` collection with creation, completion, overdue filtering, and aggregate summaries.
+- `pytest` test suite demonstrating common behaviors.
+
+## Getting started (local)
+1. Clone the repo:
+    ```bash
+    git clone https://github.com/BravelyBaby/psychic-barnacle.git
+    cd psychic-barnacle
+    ```
+2. Create a virtual environment (recommended) and install the optional development dependencies:
+    ```bash
+    python -m venv .venv
+    source .venv/bin/activate
+    pip install -e .[dev]
+    ```
+3. Run the test suite:
+    ```bash
+    make test
+    ```
+4. Explore the task primitives in a Python shell:
+    ```python
+    >>> from psychic_barnacle import TaskManager
+    >>> manager = TaskManager()
+    >>> manager.create_task("Draft release notes", priority=2)
+    >>> manager.summary()
+    {'total': 1, 'completed': 0, 'pending': 1, 'overdue': 0, 'by_priority': {2: 1}}
+    ```
 
  Devcontainer and environment
  - A minimal devcontainer is included at `.devcontainer/devcontainer.json`. It provides an Ubuntu base image and common CLI tools. Customize it if you add language toolchains (Node, Python, etc.).
@@ -36,11 +50,11 @@
      $BROWSER <url>
      ```
 
- Project layout
- - `src/` — application source (create as needed)
- - `docs/` — documentation and design notes
- - `tests/` — test suites (see `tests/README.md`)
- - `.github/` — PR templates, workflows, and actions
+## Project layout
+- `src/psychic_barnacle/` — Python package with task primitives
+- `tests/` — pytest suite (see `tests/README.md`)
+- `docs/` — documentation and design notes (create as needed)
+- `.github/` — PR templates, workflows, and actions
 
  Common commands
  - Update system packages:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "psychic-barnacle"
+version = "0.1.0"
+description = "Lightweight task management primitives for Psychic Barnacle"
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [{name = "Psychic Barnacle Maintainers"}]
+keywords = ["tasks", "productivity", "cli"]
+classifiers = [
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "License :: Other/Proprietary License",
+    "Operating System :: OS Independent",
+]
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4",
+]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+addopts = "-q"

--- a/src/psychic_barnacle/__init__.py
+++ b/src/psychic_barnacle/__init__.py
@@ -1,0 +1,5 @@
+"""Core functionality for the Psychic Barnacle task toolkit."""
+
+from .tasks import Task, TaskManager
+
+__all__ = ["Task", "TaskManager"]

--- a/src/psychic_barnacle/tasks.py
+++ b/src/psychic_barnacle/tasks.py
@@ -1,0 +1,162 @@
+"""Task management primitives for lightweight productivity tooling.
+
+The module purposely focuses on in-memory manipulation so it can serve as a
+foundation for CLI tools, web APIs, or automations that require simple task
+tracking without external storage dependencies.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field, replace
+from datetime import date
+from typing import Iterable, List, MutableSequence, Optional, Sequence
+
+
+@dataclass(order=True)
+class Task:
+    """A single unit of work tracked by the task manager.
+
+    Ordering is derived from completion state, priority, due date, and title so
+    that sorting favors actionable work: incomplete tasks with higher priority
+    and imminent due dates appear first.
+    """
+
+    sort_index: tuple = field(init=False, repr=False)
+    title: str
+    priority: int = 3
+    due_date: Optional[date] = None
+    completed: bool = False
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        title = self.title.strip()
+        if not title:
+            raise ValueError("Task title cannot be empty.")
+        if not 1 <= self.priority <= 5:
+            raise ValueError("Priority must be between 1 (highest) and 5 (lowest).")
+        self.title = title
+        normalized_due = self.due_date or date.max
+        self.sort_index = (
+            self.completed,
+            self.priority,
+            normalized_due,
+            self.title.lower(),
+        )
+
+    def mark_complete(self) -> None:
+        """Mark the task as completed and update its sort index."""
+
+        if not self.completed:
+            self.completed = True
+            self.sort_index = (
+                self.completed,
+                self.priority,
+                self.due_date or date.max,
+                self.title.lower(),
+            )
+
+    def to_dict(self) -> dict:
+        """Serialize the task for storage or APIs."""
+
+        return {
+            "title": self.title,
+            "priority": self.priority,
+            "due_date": self.due_date.isoformat() if self.due_date else None,
+            "completed": self.completed,
+            "notes": self.notes,
+        }
+
+
+class TaskManager:
+    """Container that manages a collection of :class:`Task` instances."""
+
+    def __init__(self, tasks: Iterable[Task] | None = None) -> None:
+        self._tasks: MutableSequence[Task] = []
+        if tasks:
+            for task in tasks:
+                self.add_task(task)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial delegation
+        return len(self._tasks)
+
+    def __iter__(self):  # pragma: no cover - trivial delegation
+        return iter(self._tasks)
+
+    def add_task(self, task: Task) -> Task:
+        """Add an existing :class:`Task` to the manager.
+
+        A defensive copy is stored so that external references cannot mutate the
+        manager's state unexpectedly.
+        """
+
+        task_copy = replace(task)
+        self._tasks.append(task_copy)
+        self._tasks.sort()
+        return task_copy
+
+    def create_task(
+        self,
+        title: str,
+        *,
+        priority: int = 3,
+        due_date: Optional[date] = None,
+        notes: str = "",
+    ) -> Task:
+        """Create, store, and return a new task."""
+
+        task = Task(title=title, priority=priority, due_date=due_date, notes=notes)
+        return self.add_task(task)
+
+    def list_tasks(self, *, include_completed: bool = True) -> List[Task]:
+        """Return tasks sorted according to their natural ordering."""
+
+        tasks: Sequence[Task] = self._tasks
+        if include_completed:
+            return list(tasks)
+        return [task for task in tasks if not task.completed]
+
+    def complete_task(self, title: str) -> Task:
+        """Mark the first matching incomplete task as complete.
+
+        Raises:
+            KeyError: If no incomplete task with the provided title exists.
+        """
+
+        for task in self._tasks:
+            if task.title.lower() == title.strip().lower() and not task.completed:
+                task.mark_complete()
+                self._tasks.sort()
+                return task
+        raise KeyError(f"No pending task found with title '{title}'.")
+
+    def get_overdue(self, today: Optional[date] = None) -> List[Task]:
+        """Return incomplete tasks whose due date has passed."""
+
+        today = today or date.today()
+        overdue: List[Task] = []
+        for task in self._tasks:
+            if task.completed:
+                continue
+            if task.due_date and task.due_date < today:
+                overdue.append(task)
+        return overdue
+
+    def summary(self) -> dict:
+        """Provide aggregate statistics about the task collection."""
+
+        total = len(self._tasks)
+        completed = sum(1 for task in self._tasks if task.completed)
+        pending = total - completed
+        overdue = len(self.get_overdue())
+        by_priority = Counter(task.priority for task in self._tasks)
+        return {
+            "total": total,
+            "completed": completed,
+            "pending": pending,
+            "overdue": overdue,
+            "by_priority": dict(sorted(by_priority.items())),
+        }
+
+
+__all__ = ["Task", "TaskManager"]

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,58 @@
+from datetime import date, timedelta
+
+import pytest
+
+from psychic_barnacle import Task, TaskManager
+
+
+def test_task_validation():
+    with pytest.raises(ValueError):
+        Task(title="   ")
+    with pytest.raises(ValueError):
+        Task(title="Invalid priority", priority=0)
+
+
+def test_task_ordering_and_listing():
+    manager = TaskManager()
+    manager.create_task("Low priority", priority=5)
+    manager.create_task("High priority", priority=1)
+    manager.create_task("Medium priority", priority=3)
+
+    tasks = manager.list_tasks(include_completed=False)
+    titles = [task.title for task in tasks]
+    assert titles == ["High priority", "Medium priority", "Low priority"]
+
+
+def test_complete_task_updates_state():
+    manager = TaskManager()
+    manager.create_task("Write docs")
+    manager.create_task("Ship release")
+
+    completed = manager.complete_task("write docs")
+    assert completed.completed is True
+    assert completed.title == "Write docs"
+
+    with pytest.raises(KeyError):
+        manager.complete_task("Write docs")
+
+
+def test_overdue_and_summary():
+    today = date(2024, 1, 10)
+    manager = TaskManager(
+        [
+            Task("Submit report", due_date=today - timedelta(days=1)),
+            Task("Plan roadmap", priority=2),
+            Task("Team sync", priority=2, completed=True, due_date=today - timedelta(days=2)),
+        ]
+    )
+
+    overdue = manager.get_overdue(today=today)
+    assert len(overdue) == 1
+    assert overdue[0].title == "Submit report"
+
+    summary = manager.summary()
+    assert summary["total"] == 3
+    assert summary["completed"] == 1
+    assert summary["pending"] == 2
+    assert summary["overdue"] == 1
+    assert summary["by_priority"][2] == 2


### PR DESCRIPTION
## Summary
- add a Python task management package with Task and TaskManager primitives
- configure project metadata and pytest defaults for the new package
- refresh documentation, gitignore, and test command to match the Python setup

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d9716bcc84832bab2005d40566790c